### PR TITLE
Refactor groupId

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -8,10 +8,12 @@
       <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
    </properties>
 
-   <groupId>fr.gael.cortex</groupId>
+   <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
    <artifactId>drbx-cortex-topic-sentinel-2-commons</artifactId>
    <packaging>jar</packaging>
    <version>1.0.0</version>
+
+   <name>Cortex Topics for Sentinel-2 Commons</name>
 
    <parent>
       <groupId>fr.gael</groupId>

--- a/level-0/pom.xml
+++ b/level-0/pom.xml
@@ -8,10 +8,12 @@
       <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
    </properties>
 
-   <groupId>fr.gael.cortex</groupId>
+   <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
    <artifactId>drbx-cortex-topic-sentinel-2-level-0</artifactId>
    <packaging>jar</packaging>
    <version>1.0.0</version>
+
+   <name>Cortex Topics for Sentinel-2 Level 0</name>
 
    <parent>
       <groupId>fr.gael</groupId>
@@ -22,7 +24,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>fr.gael.cortex</groupId>
+         <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
          <artifactId>drbx-cortex-topic-sentinel-2-commons</artifactId>
          <version>1.0.0</version>
       </dependency>

--- a/level-1a/pom.xml
+++ b/level-1a/pom.xml
@@ -4,10 +4,16 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>fr.gael.cortex</groupId>
-    <artifactId>drbx-cortex-topic-sentinel-2-level-1a</artifactId>
-    <packaging>jar</packaging>
-    <version>1.0.0</version>
+   <properties>
+      <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
+   </properties>
+
+   <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
+   <artifactId>drbx-cortex-topic-sentinel-2-level-1a</artifactId>
+   <packaging>jar</packaging>
+   <version>1.0.0</version>
+
+   <name>Cortex Topics for Sentinel-2 Level 1A</name>
 
    <parent>
       <groupId>fr.gael</groupId>
@@ -18,7 +24,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>fr.gael.cortex</groupId>
+         <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
          <artifactId>drbx-cortex-topic-sentinel-2-commons</artifactId>
          <version>1.0.0</version>
       </dependency>

--- a/level-1b/pom.xml
+++ b/level-1b/pom.xml
@@ -8,10 +8,12 @@
       <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
    </properties>
 
-   <groupId>fr.gael.cortex</groupId>
+   <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
    <artifactId>drbx-cortex-topic-sentinel-2-level-1b</artifactId>
    <packaging>jar</packaging>
    <version>1.0.0</version>
+
+   <name>Cortex Topics for Sentinel-2 Level 1B</name>
 
    <parent>
       <groupId>fr.gael</groupId>
@@ -22,7 +24,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>fr.gael.cortex</groupId>
+         <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
          <artifactId>drbx-cortex-topic-sentinel-2-commons</artifactId>
          <version>1.0.0</version>
       </dependency>

--- a/level-1c/pom.xml
+++ b/level-1c/pom.xml
@@ -8,10 +8,12 @@
       <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
    </properties>
 
-   <groupId>fr.gael.cortex</groupId>
+   <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
    <artifactId>drbx-cortex-topic-sentinel-2-level-1c</artifactId>
    <packaging>jar</packaging>
    <version>1.0.0</version>
+
+   <name>Cortex Topics for Sentinel-2 Level 1C</name>
 
    <parent>
       <groupId>fr.gael</groupId>
@@ -22,7 +24,7 @@
 
    <dependencies>
       <dependency>
-         <groupId>fr.gael.cortex</groupId>
+         <groupId>fr.gael.drb.cortex.sentinel-2</groupId>
          <artifactId>drbx-cortex-topic-sentinel-2-commons</artifactId>
          <version>1.0.0</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
-   <groupId>fr.gael.cortex</groupId>
-   <artifactId>drbx-cortex-topic-sentinel-2</artifactId>
+   <groupId>fr.gael.drb.cortex</groupId>
+   <artifactId>sentinel-2</artifactId>
    <packaging>pom</packaging>
    <version>1.0.0</version>
 
-   <name>Cortex Topics for Sentinel-2</name>
+   <name>Cortex Topics for Sentinel-2 Suite</name>
 
    <parent>
       <groupId>fr.gael</groupId>


### PR DESCRIPTION
GroupId is also the deployment path. These topics are part of drb, and cortex, so fr.gael.drb.cortex.sentinel-2 groupId is preferred to fr.gael.cortex. This topic splits sentinel-2 into 4 topics that must be gathered into a "sentinel-2" container.

In addition names of the packages has been set.